### PR TITLE
Exempt nuxt plugin from SSR

### DIFF
--- a/src/nuxt-module.ts
+++ b/src/nuxt-module.ts
@@ -5,7 +5,8 @@ import { PlausibleOptions } from 'plausible-tracker'
 const PlausibleModule: Module<PlausibleOptions> = function (moduleOptions) {
   this.addPlugin({
     src: path.resolve(__dirname, './nuxt-plugin.js'),
-    options: moduleOptions
+    options: moduleOptions,
+    ssr: false
   })
 }
 


### PR DESCRIPTION
This caused problems in my Nuxt installation resulting in the error message `history is not defined` originating in `plausible-tracker/src/lib/tracker.ts:240:31`.