### PR TITLE
Add missing default value for the apiHost setting of the nuxt plugin

### DIFF
--- a/src/nuxt-plugin.ts
+++ b/src/nuxt-plugin.ts
@@ -11,7 +11,7 @@ const PlausiblePlugin: Plugin = (context, inject) => {
     domain: optionsDomain.length ? optionsDomain : null,
     hashMode: optionsHashMode === 'true',
     trackLocalhost: optionsTrackLocalhost === 'true',
-    apiHost: optionsApiHost.length ? optionsApiHost : null
+    apiHost: optionsApiHost.length ? optionsApiHost : 'https://plausible.io'
   } as PlausibleOptions
 
   const plausible = Plausible(options)


### PR DESCRIPTION
The Nuxt plugin creates its own default options object. These default options are missing a value for the `apiHost` key, requiring the user to explicitly set its value to `https://plausible.io`, even though this is probably the desired value for most users.