### PR TITLE
fix: inject esm plugin in nuxt environment

### DIFF
--- a/src/nuxt-module.ts
+++ b/src/nuxt-module.ts
@@ -1,3 +1,4 @@
+import path from 'path'
 import { Module } from '@nuxt/types'
 import { PlausibleOptions } from 'plausible-tracker'
 
@@ -17,7 +18,7 @@ const PlausibleModule: Module<PlausibleOptions> = function (moduleOptions) {
   }
 
   this.addPlugin({
-    src: require.resolve('../esm/nuxt-plugin.js'),
+    src: path.resolve(__dirname, '../esm/nuxt-plugin.js'),
     mode: 'client',
     ssr: false,
     fileName: 'vue-plausible.client.js',

--- a/src/nuxt-module.ts
+++ b/src/nuxt-module.ts
@@ -1,4 +1,3 @@
-import path from 'path'
 import { Module } from '@nuxt/types'
 import { PlausibleOptions } from 'plausible-tracker'
 
@@ -18,7 +17,7 @@ const PlausibleModule: Module<PlausibleOptions> = function (moduleOptions) {
   }
 
   this.addPlugin({
-    src: path.resolve(__dirname, './nuxt-plugin.js'),
+    src: require.resolve('../esm/nuxt-plugin.js'),
     mode: 'client',
     ssr: false,
     fileName: 'vue-plausible.client.js',


### PR DESCRIPTION
There should be no need to inject a CJS plugin as Nuxt will already be transpiling files in `.nuxt` - and this way, we can be compatible with `nuxt-vite` 🥳 

If you'd like, I can also make this properly esm/pnp compatible by adding `exports` field in `package.json` and using `require.resolve`, but didn't want to conflate the issues.