### PR TITLE
Use Nuxt runtime config

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,16 @@ export default {
   ],
   plausible: {
     // see configuration section
-  }
+  },
   // ...
+  // Or use publicRuntimeConfig to allow dotenv configuration over
+  // different environments
+  publicRuntimeConfig: {
+    plausible: {
+      domain: process.env.PLAUSIBLE_DOMAIN || null,
+      apiHost: process.env.PLAUSIBLE_API_HOST || 'https://plausible.io',
+    },
+  }
 }
 ```
 

--- a/src/nuxt-module.ts
+++ b/src/nuxt-module.ts
@@ -11,13 +11,11 @@ const defaultOptions: PlausibleOptions = {
 }
 
 const PlausibleModule: Module<PlausibleOptions> = function (moduleOptions) {
-  const { nuxt } = this
-
   const options = {
     ...defaultOptions,
     ...this.options.plausible,
     ...moduleOptions,
-    ...nuxt.options.runtimeConfig?.plausible
+    ...this.nuxt.options.runtimeConfig?.plausible
   }
 
   this.addPlugin({

--- a/src/nuxt-module.ts
+++ b/src/nuxt-module.ts
@@ -11,10 +11,13 @@ const defaultOptions: PlausibleOptions = {
 }
 
 const PlausibleModule: Module<PlausibleOptions> = function (moduleOptions) {
+  const { nuxt } = this
+
   const options = {
     ...defaultOptions,
     ...this.options.plausible,
-    ...moduleOptions
+    ...moduleOptions,
+    ...nuxt.options.runtimeConfig?.plausible
   }
 
   this.addPlugin({

--- a/src/nuxt-plugin.ts
+++ b/src/nuxt-plugin.ts
@@ -11,8 +11,7 @@ const PlausiblePlugin: Plugin = (context, inject) => {
     domain: optionsDomain.length ? optionsDomain : null,
     hashMode: optionsHashMode === 'true',
     trackLocalhost: optionsTrackLocalhost === 'true',
-    apiHost: optionsApiHost.length ? optionsApiHost : 'https://plausible.io',
-    ...context.$config?.plausible
+    apiHost: optionsApiHost.length ? optionsApiHost : 'https://plausible.io'
   } as PlausibleOptions
 
   if (options.domain !== null) {

--- a/src/nuxt-plugin.ts
+++ b/src/nuxt-plugin.ts
@@ -11,7 +11,8 @@ const PlausiblePlugin: Plugin = (context, inject) => {
     domain: optionsDomain.length ? optionsDomain : null,
     hashMode: optionsHashMode === 'true',
     trackLocalhost: optionsTrackLocalhost === 'true',
-    apiHost: optionsApiHost.length ? optionsApiHost : 'https://plausible.io'
+    apiHost: optionsApiHost.length ? optionsApiHost : 'https://plausible.io',
+    ...context.$config?.plausible
   } as PlausibleOptions
 
   if (options.domain !== null) {

--- a/src/nuxt-plugin.ts
+++ b/src/nuxt-plugin.ts
@@ -14,9 +14,11 @@ const PlausiblePlugin: Plugin = (context, inject) => {
     apiHost: optionsApiHost.length ? optionsApiHost : 'https://plausible.io'
   } as PlausibleOptions
 
-  const plausible = Plausible(options)
-  plausible.enableAutoPageviews()
-  inject('plausible', plausible)
+  if (options.domain !== null) {
+    const plausible = Plausible(options)
+    plausible.enableAutoPageviews()
+    inject('plausible', plausible)
+  }
 }
 
 export default PlausiblePlugin


### PR DESCRIPTION
Fixes #10 

This would allow changing Plausible options over different environments (dev, testing, production) using [Nuxt `runtimeConfig`](https://nuxtjs.org/docs/2.x/directory-structure/nuxt-config#runtimeconfig).