### PR TITLE
Switched Nuxt runtime configuration overriding from Module to Plugin

### DIFF
--- a/src/nuxt-module.ts
+++ b/src/nuxt-module.ts
@@ -14,8 +14,7 @@ const PlausibleModule: Module<PlausibleOptions> = function (moduleOptions) {
   const options = {
     ...defaultOptions,
     ...this.options.plausible,
-    ...moduleOptions,
-    ...this.nuxt.options.runtimeConfig?.plausible
+    ...moduleOptions
   }
 
   this.addPlugin({

--- a/src/nuxt-plugin.ts
+++ b/src/nuxt-plugin.ts
@@ -11,7 +11,9 @@ const PlausiblePlugin: Plugin = (context, inject) => {
     domain: optionsDomain.length ? optionsDomain : null,
     hashMode: optionsHashMode === 'true',
     trackLocalhost: optionsTrackLocalhost === 'true',
-    apiHost: optionsApiHost.length ? optionsApiHost : 'https://plausible.io'
+    apiHost: optionsApiHost.length ? optionsApiHost : 'https://plausible.io',
+    // Override plugin configuration with Nuxt Runtime config without re-building
+    ...context.$config?.plausible
   } as PlausibleOptions
 
   if (options.domain !== null) {


### PR DESCRIPTION
Nuxt Runtime configuration was used in module instead of plugin. Preventing any *runtime* config to work without a rebuild.