### PR TITLE
Let Plausible fallback to location.hostname if no domain

### DIFF
--- a/src/nuxt-plugin.ts
+++ b/src/nuxt-plugin.ts
@@ -10,8 +10,7 @@ const PlausiblePlugin: Plugin = (context, inject) => {
   const optionsEnableAutoPageviews = '<%= options.enableAutoPageviews %>' as any
   const optionsEnableAutoOutboundTracking = '<%= options.enableAutoOutboundTracking %>' as any
 
-  const options = {
-    domain: optionsDomain.length ? optionsDomain : null,
+  let options = {
     hashMode: optionsHashMode === 'true',
     trackLocalhost: optionsTrackLocalhost === 'true',
     apiHost: optionsApiHost.length ? optionsApiHost : 'https://plausible.io',
@@ -21,18 +20,23 @@ const PlausiblePlugin: Plugin = (context, inject) => {
     ...context.$config?.plausible
   } as PlausibleModuleOptions
 
-  if (options.domain !== null) {
-    const plausible = Plausible(options)
-
-    if (options.enableAutoPageviews === true) {
-      plausible.enableAutoPageviews()
+  if (optionsDomain.length) {
+    options = {
+      ...options,
+      domain: optionsDomain
     }
-    if (options.enableAutoOutboundTracking === true) {
-      plausible.enableAutoOutboundTracking()
-    }
-
-    inject('plausible', plausible)
   }
+
+  const plausible = Plausible(options)
+
+  if (options.enableAutoPageviews === true) {
+    plausible.enableAutoPageviews()
+  }
+  if (options.enableAutoOutboundTracking === true) {
+    plausible.enableAutoOutboundTracking()
+  }
+
+  inject('plausible', plausible)
 }
 
 export default PlausiblePlugin


### PR DESCRIPTION
Like the README says, domain _should_ be optional, with a fallback to location.hostname:

| Option | Type | Description | Default |
| ------ | ---- | ----------- | ------- |
| domain | `string` | Your site's domain name, as declared by you in Plausible's settings. | `location.hostname` |

However, this didn't happen because the Nuxt plugin defers instantiating the tracking entirely if the domain is not set:
https://github.com/moritzsternemann/vue-plausible/blob/02c72183762e5bd72ff7771003c6b91743cde14e/src/nuxt-plugin.ts#L24

This PR changes the behavior to still start up the tracker, and let it perform its internal fallback strategy instead of doing nothing.
