### PR TITLE
fix: hotfix provide for nuxt 3

### DIFF
--- a/src/nuxt-plugin.ts
+++ b/src/nuxt-plugin.ts
@@ -36,7 +36,13 @@ const PlausiblePlugin: Plugin = (context, inject) => {
     plausible.enableAutoOutboundTracking()
   }
 
-  inject('plausible', plausible)
+  if (inject) {
+    // Nuxt 2
+    inject('plausible', plausible)
+  } else {
+    // Nuxt 3
+    context.provide('plausible', plausible)
+  }
 }
 
 export default PlausiblePlugin


### PR DESCRIPTION
With https://github.com/nuxt/framework/pull/5630, we now no longer provide an `inject` function, so if a user is using Nuxt 3, this plugin will cause a silent error.

This PR isn't full proper support for nuxt 3, but just a small hotfix that should alleviate some breakage.